### PR TITLE
Delete descriptor.mod

### DIFF
--- a/descriptor.mod
+++ b/descriptor.mod
@@ -1,9 +1,0 @@
-version="0.1"
-tags={
-	"Historical"
-	"Religion"
-	"Events"
-	"Alternative History"
-}
-name="IR-CK3_TFE-Rise of Islam"
-supported_version="1.7.*"


### PR DESCRIPTION
It's not needed because the files will be merged by the converter into the generated mod.